### PR TITLE
Configure elastic search to be accessible from outside

### DIFF
--- a/search-box/components/elastic/defaults/main.yml
+++ b/search-box/components/elastic/defaults/main.yml
@@ -16,3 +16,4 @@ es_start_options:
 
 # Configuration file
 es_config_file:
+    network.host: 0.0.0.0

--- a/search-box/components/elastic/tasks/main.yml
+++ b/search-box/components/elastic/tasks/main.yml
@@ -36,10 +36,10 @@
 #  when: es_uid
 #  tags: [elasticsearch]
 
-#- name: set elasticsearch configuration
-#  template: src=elasticsearch.yml.j2 dest=/etc/elasticsearch mode=0644 owner=root group=root
-#  notify: restart elasticsearch
-#  tags: [elasticsearch]
+- name: set elasticsearch configuration
+  template: src=elasticsearch.yml.j2 dest=/etc/elasticsearch/elasticsearch.yml mode=0644 owner=root group=root
+  notify: restart elasticsearch
+  tags: [elasticsearch]
 
 # set limits.conf
 - name: limits.conf tuning


### PR DESCRIPTION
When upping the search box I'd like to use ES from other vms, so the search service must be available on 10.0.0.21:9200.